### PR TITLE
fix: 회원가입/로그인 페이지에서 오류체크 안하고 넘어가는 문제 수정 (#7)

### DIFF
--- a/src/components/ui/header/AccountButton.jsx
+++ b/src/components/ui/header/AccountButton.jsx
@@ -8,9 +8,13 @@ const AccountButton = () => {
   const session = useContext(SessionContext);
   const navigate = useNavigate();
 
-  const handleLogOut = () => {
-    signOut();
-    navigate("/");
+  const handleLogOut = async () => {
+    const { error } = await signOut();
+    if (error) {
+      alert("로그아웃에 실패했습니다.");
+    } else {
+      navigate("/");
+    }
   };
   const handleLogIn = () => {
     navigate("/login");

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -16,7 +16,7 @@ const LogIn = () => {
     password: "",
   });
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
 
     const emailError = validateEmail(formData.email);
@@ -27,13 +27,22 @@ const LogIn = () => {
       password: passwordError,
     });
 
-    if (!errors.email.length && !errors.password.length) {
-      try {
-        logIn({ email: formData.email, password: formData.password });
-        navigate("/");
-      } catch {
+    if (!emailError.length && !passwordError.length) {
+      const { error } = await logIn({ email: formData.email, password: formData.password });
+
+      if (error) {
         alert("오류가 발생했습니다.");
+      } else {
+        navigate("/");
       }
+    }
+  };
+
+  const handleKakaoLogIn = async () => {
+    const { error } = await signInWithKakao();
+
+    if (error) {
+      alert("카카오 로그인에 실패했습니다.");
     }
   };
 
@@ -65,7 +74,7 @@ const LogIn = () => {
         <Button className={"mt-4"} type="submit">
           로그인
         </Button>
-        <Button onClick={() => signInWithKakao()}>카카오 로그인</Button>
+        <Button onClick={handleKakaoLogIn}>카카오 로그인</Button>
         <div className="text-sm flex items-center mt-4">
           오즈 무비가 처음이신가요?{" "}
           <Button className={"bg-white text-black underline"} onClick={() => navigate("/signup")}>

--- a/src/pages/Signup.jsx
+++ b/src/pages/Signup.jsx
@@ -44,16 +44,21 @@ const SignUp = () => {
     });
 
     if (
-      !errors.email.length &&
-      !errors.password.length &&
-      !errors.name.length &&
-      !errors.passwordConfirm.length
+      !emailError.length &&
+      !passwordError.length &&
+      !nameError.length &&
+      !passwordConfirmError.length
     ) {
-      try {
-        signUp({ email: formData.email, name: formData.name, password: formData.password });
+      const { error } = await signUp({
+        email: formData.email,
+        name: formData.name,
+        password: formData.password,
+      });
+
+      if (error) {
+        alert("에러가 발생했습니다.");
+      } else {
         navigate("/login");
-      } catch (error) {
-        console.error(error);
       }
     }
   };
@@ -96,7 +101,7 @@ const SignUp = () => {
       <h1 className="mb-8 text-2xl">회원가입</h1>
       <form className="flex flex-col gap-4" onSubmit={handleSubmit}>
         {INPUT_DATA.map((data) => (
-          <LabeledInput key={data.name} {...data} />
+          <LabeledInput key={data.title} {...data} />
         ))}
         <Button type="submit">회원가입</Button>
       </form>

--- a/src/supabase/auth/auth.js
+++ b/src/supabase/auth/auth.js
@@ -1,48 +1,47 @@
 import supabase from "@src/supabase/supabaseClient";
 
 export const logIn = async ({ email, password }) => {
-  await supabase.auth
-    .signInWithPassword({
-      email,
-      password,
-    })
-    .catch((error) => {
-      throw error;
-    });
+  const { data, error } = await supabase.auth.signInWithPassword({
+    email,
+    password,
+  });
+  return { data, error };
 };
 
 export const signUp = async ({ email, name, password }) => {
-  const { data, error } = await supabase.auth.signUp({
+  const { data: authData, error: authError } = await supabase.auth.signUp({
     email,
     password,
   });
 
-  if (error) {
-    throw error;
+  if (authError) {
+    return { data: null, error: authError };
   }
 
-  await supabase.from("user_table").insert({
-    created_at: data.user?.created_at,
-    email: data.user?.email,
-    id: data.user?.id,
+  const { error: insertError } = await supabase.from("user_table").insert({
+    created_at: authData.user?.created_at,
+    email: authData.user?.email,
+    id: authData.user?.id,
     name,
   });
+
+  if (insertError) {
+    return { data: null, error: insertError };
+  }
+
+  return { data: authData, error: null };
 };
 
 export const signOut = async () => {
   const { error } = await supabase.auth.signOut();
 
-  if (error) {
-    throw error;
-  }
+  return { data: null, error };
 };
 
 export const signInWithKakao = async () => {
-  const { error } = await supabase.auth.signInWithOAuth({
+  const { data, error } = await supabase.auth.signInWithOAuth({
     provider: "kakao",
   });
 
-  if (error) {
-    throw error;
-  }
+  return { data, error };
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

> #7

## 📝작업 내용

> 회원가입/로그인 페이지에서 오류체크 안하고 넘어가는 문제 수정
- auth.js안의 함수들이 {data, error}를 반환하도록 수정
- auth.js의 함수들 반환값 변경에 따라, 함수들을 사용하는 부분들에서 try catch 문을 제거하고 반환된 값을 사용하도록 수정
- 회원가입/로그인 페이지의 error length를 확인하는 부분을 error state가 아닌 emailError 등 값을 사용하도록 수정
- 회원가입 페이지 LabeledInput의 key를 data.title로 수정

