### PR TITLE
refactor: 검색 페이지 분리(#25)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import LogIn from "@pages/LogIn";
 import Main from "@pages/Main";
 import MovieDetail from "@pages/MovieDetail";
 import NotFound from "@pages/NotFound";
+import Search from "@pages/Search";
 import SignUp from "@pages/SignUp";
 import { Route, Routes } from "react-router";
 
@@ -19,6 +20,10 @@ const App = () => {
     {
       element: <LogIn />,
       path: "login",
+    },
+    {
+      element: <Search />,
+      path: "search",
     },
     {
       element: <MovieDetail />,

--- a/src/components/ui/header/SearchBar.jsx
+++ b/src/components/ui/header/SearchBar.jsx
@@ -1,4 +1,4 @@
-import { MAIN_URL } from "@constants/urls";
+import { SEARCH_URL } from "@constants/urls";
 import { useDebounce } from "@hooks/useDebounce";
 import { cn } from "@utils/cn";
 import { useNavigate } from "react-router";
@@ -9,7 +9,7 @@ const SearchBar = () => {
     <input
       className={cn("flex h-10 w-100 items-center rounded-3xl px-6 shadow-md")}
       onChange={useDebounce((e) => {
-        navigate(`${MAIN_URL}?query=${e.target.value}`);
+        navigate(`${SEARCH_URL}?query=${e.target.value}`);
       })}
       placeholder="검색어를 입력하세요"
     />

--- a/src/constants/urls.js
+++ b/src/constants/urls.js
@@ -2,3 +2,4 @@ export const MAIN_URL = "/";
 export const SIGN_UP_URL = "/signup";
 export const LOG_IN_URL = "/login";
 export const DETAIL_URL = "/details";
+export const SEARCH_URL = "/search";

--- a/src/pages/Main.jsx
+++ b/src/pages/Main.jsx
@@ -1,37 +1,13 @@
-import { findByMovieTitle } from "@api/findByMovieTitle";
 import { getPopularMovies } from "@api/getPopularMovies";
 import MovieCardsContainer from "@components/ui/common/MovieCard/MovieCardsContainer";
 import MovieCardsContainerSkeleton from "@components/ui/common/MovieCard/MovieCardsContainerSkeleton";
-import { MAIN_URL } from "@constants/urls";
 import { useFetch } from "@hooks/useFetch";
-import { useEffect } from "react";
 import { ErrorBoundary } from "react-error-boundary";
-import { useNavigate, useSearchParams } from "react-router";
 
 function Main() {
-  const [searchParams] = useSearchParams();
-  const navigate = useNavigate();
-  const urlQuery = searchParams.get("query");
-
-  useEffect(() => {
-    if (searchParams.has("query") && !urlQuery) {
-      navigate(MAIN_URL);
-    }
-  }, [navigate, searchParams, urlQuery]);
-
-  const { data: searchResults, isLoading: searchIsLoading } = useFetch({
-    enabled: urlQuery,
-    options: { query: urlQuery },
-    query: findByMovieTitle,
-  });
-
-  const { data: popularMovies, isLoading: popularIsLoading } = useFetch({
-    enabled: !urlQuery,
+  const { data, isLoading } = useFetch({
     query: getPopularMovies,
   });
-
-  const data = searchResults || popularMovies;
-  const isLoading = searchIsLoading || popularIsLoading;
 
   if (isLoading) {
     return <MovieCardsContainerSkeleton />;
@@ -43,7 +19,7 @@ function Main() {
     <ErrorBoundary fallback={<div>에러 발생</div>}>
       <div className="flex flex-col gap-8 lg:max-w-5xl xl:max-w-7xl 2xl:max-w-full">
         <div>
-          <h2 className="h2 relative left-1">{urlQuery ? "검색 결과" : "인기 영화"}</h2>
+          <h2 className="h2 relative left-1">인기 영화</h2>
           {data?.results && <MovieCardsContainer movieListData={allAgesMovieList} />}
         </div>
       </div>

--- a/src/pages/Search.jsx
+++ b/src/pages/Search.jsx
@@ -1,0 +1,37 @@
+import { findByMovieTitle } from "@api/findByMovieTitle";
+import MovieCardsContainer from "@components/ui/common/MovieCard/MovieCardsContainer";
+import MovieCardsContainerSkeleton from "@components/ui/common/MovieCard/MovieCardsContainerSkeleton";
+import { useFetch } from "@hooks/useFetch";
+import { ErrorBoundary } from "react-error-boundary";
+import { useSearchParams } from "react-router";
+
+const Search = () => {
+  const [searchParams] = useSearchParams();
+  const urlQuery = searchParams.get("query");
+
+  const { data, isLoading } = useFetch({
+    options: { query: urlQuery },
+    query: findByMovieTitle,
+  });
+
+  return (
+    <ErrorBoundary fallback={<div>에러 발생</div>}>
+      <div className="flex flex-col gap-8 lg:max-w-5xl xl:max-w-7xl 2xl:max-w-full">
+        <div className="flex flex-col items-center gap-2">
+          <div className="font-extralight text-4xl">
+            {urlQuery ? urlQuery : "검색어가 없습니다"}
+          </div>
+          <h2 className="h2 relative font-medium">{urlQuery && "검색 결과"}</h2>
+        </div>
+        <div>
+          {isLoading ? (
+            <MovieCardsContainerSkeleton />
+          ) : (
+            data?.results && <MovieCardsContainer movieListData={data.results} />
+          )}
+        </div>
+      </div>
+    </ErrorBoundary>
+  );
+};
+export default Search;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #25

## 📝작업 내용

> 검색 페이지 분리
- Search route 추가
- constant/urls에 SEARCH_URL 상수 추가
- SearchBar 컴포넌트에서 입력했을 때 이동하는 페이지를 Search 페이지로 수종
- 검색어가 없을 때 Main 페이지로 이동하는 부분 수정, '검색어가 없습니다' 표시
- 검색어 표시

