### PR TITLE
feat: 무한 스크롤 구현(#27)

### DIFF
--- a/src/api/getPopularMovies.js
+++ b/src/api/getPopularMovies.js
@@ -1,7 +1,7 @@
-export const getPopularMovies = async ({ config }) => {
+export const getPopularMovies = async ({ config, pageNumber }) => {
   const response = await fetch(
-    "https://api.themoviedb.org/3/movie/popular?language=ko-KR&page=1",
-    config,
+    `https://api.themoviedb.org/3/movie/popular?language=ko-KR&page=${pageNumber}`,
+    config
   );
 
   if (!response.ok) {

--- a/src/components/ui/common/MovieCard/MovieCardsContainer.jsx
+++ b/src/components/ui/common/MovieCard/MovieCardsContainer.jsx
@@ -1,11 +1,14 @@
 import MovieCard from "@components/ui/common/MovieCard/MovieCard";
+import MovieCardSkeleton from "@components/ui/common/MovieCard/MovieCardSkeleton";
 
-const MovieCardsContainer = ({ movieListData }) => {
+const MovieCardsContainer = ({ isLoading = false, movieListData, skeletonSize = 10 }) => {
   return (
     <section className="grid w-fit grid-cols-1 gap-2 pb-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
       {movieListData?.map((movieData) => (
         <MovieCard key={movieData.id} {...movieData} />
       ))}
+      {isLoading &&
+        Array.from({ length: skeletonSize }).map((_, idx) => <MovieCardSkeleton key={idx} />)}
     </section>
   );
 };

--- a/src/hooks/useIntersect.js
+++ b/src/hooks/useIntersect.js
@@ -1,0 +1,28 @@
+import { useCallback, useEffect, useRef } from "react";
+
+const useIntersect = ({ onIntersect, options }) => {
+  const ref = useRef(null);
+  const callback = useCallback(
+    (entries, observer) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          onIntersect(entry, observer);
+        }
+      });
+    },
+    [onIntersect]
+  );
+
+  useEffect(() => {
+    if (!ref.current) return;
+    const observer = new IntersectionObserver(callback, options);
+    observer.observe(ref.current);
+    return () => {
+      observer.disconnect();
+    };
+  }, [callback, options]);
+
+  return ref;
+};
+
+export default useIntersect;

--- a/src/pages/Main.jsx
+++ b/src/pages/Main.jsx
@@ -1,30 +1,57 @@
 import { getPopularMovies } from "@api/getPopularMovies";
 import MovieCardsContainer from "@components/ui/common/MovieCard/MovieCardsContainer";
-import MovieCardsContainerSkeleton from "@components/ui/common/MovieCard/MovieCardsContainerSkeleton";
 import { useFetch } from "@hooks/useFetch";
+import useIntersect from "@hooks/useIntersect";
+import { useEffect, useState } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 
 function Main() {
-  const { data, isLoading } = useFetch({
+  const [movies, setMovies] = useState([]);
+  const [pageNumber, setPageNumber] = useState(1);
+
+  const { data: newData, isLoading } = useFetch({
+    options: { pageNumber: pageNumber },
     query: getPopularMovies,
   });
 
-  if (isLoading) {
-    return <MovieCardsContainerSkeleton />;
-  }
+  useEffect(() => {
+    if (newData?.results) {
+      const allAgesMovieList = newData?.results.filter((movie) => !movie.adult);
 
-  const allAgesMovieList = data?.results.filter((movie) => !movie.adult);
+      setMovies((prevMovies) => {
+        const existingMovieIds = new Set(prevMovies.map((movie) => movie.id));
+        const nonDuplicatedMovies = allAgesMovieList.filter(
+          (movie) => !existingMovieIds.has(movie.id)
+        );
+        return [...prevMovies, ...nonDuplicatedMovies];
+      });
+    }
+  }, [newData?.results]);
+
+  const ref = useIntersect({
+    onIntersect: async (entry, observer) => {
+      observer.unobserve(entry.target);
+      if (!isLoading) {
+        setPageNumber((prev) => prev + 1);
+      }
+    },
+  });
 
   return (
     <ErrorBoundary fallback={<div>에러 발생</div>}>
       <div className="flex flex-col gap-8 lg:max-w-5xl xl:max-w-7xl 2xl:max-w-full">
         <div>
           <h2 className="h2 relative left-1">인기 영화</h2>
-          {data?.results && <MovieCardsContainer movieListData={allAgesMovieList} />}
+          <MovieCardsContainer isLoading={isLoading} movieListData={movies} />
+          <Target ref={ref} />
         </div>
       </div>
     </ErrorBoundary>
   );
+}
+
+function Target({ ref }) {
+  return <div className="h-[1px]" ref={ref}></div>;
 }
 
 export default Main;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #27

## 📝작업 내용

> 메인 페이지에서 무한 스크롤 구현
- IntersectionObserver를 사용하기 위한 useIntersect 훅 구현
- 영화 데이터를 상태로 관리하고, 데이터를 받아올 때마다 추가
- 아이디가 중복되는 데이터를 제외하기 위해 set 사용
- 영화 개수 변화에 맞춰서 스켈레톤을 표시하기 위해 MovieCardsContainer에 스켈레톤 포함
- api/getPopularMovies 가 pageNumber를 파라미터로 받도록 수정

